### PR TITLE
fix(devtools) errors while flusing will stop the scheduler

### DIFF
--- a/packages/jerni-dev/test.js
+++ b/packages/jerni-dev/test.js
@@ -42,7 +42,9 @@ module.exports = async function getJerniDevInstance(
         return;
       }
 
-      throw ex;
+      hasStopped = true;
+      await originalJourney.dispose();
+      return
     }
     buffer.length = 0;
 


### PR DESCRIPTION
we don't need to throw because there is nobody catching it in nexttick